### PR TITLE
Skip false positives from Module::ExtractUse

### DIFF
--- a/lib/Module/Overview.pm
+++ b/lib/Module/Overview.pm
@@ -97,6 +97,7 @@ sub get {
             grep { (not $recursion_filter) or ($_ =~ m/$recursion_filter/) }   # filter modules
             grep { my $s = $_; none { $_ eq $s } @{$overview{'parents'}} }     # skip parents
             grep { !$skip_kw{$_} }                                             # skip uninteresting
+            grep { $_ =~ m{^\w+(::\w+)*$} }                                    # skip false positives from Module::ExtractUse
             grep { $_ !~ m{^[0-9._]+$} }                                       # skip perl versions
             sort
             $euse->array


### PR DESCRIPTION
In general, Module::ExtractUse is not very accurate because it uses simple regexes instead of a proper scanner. For more accurate results, consider using Perl::PrereqScanner and its variants, or actually loading/running the target module and tracing its require statement (e.g. using App::FatPacker, also see App::tracepm).

When run against my Text::ANSITable, it produces Text::ANSITable::StyleSet::$name because Text/ANSITable.pm contains this line:

    require "Text/ANSITable/StyleSet/$name.pm";

This PR filters such invalid Perl module names. 